### PR TITLE
Modified the input.nml parameter fhcyc from 24. to 0.

### DIFF
--- a/parm/forecast/globnest/input.nml.tmp
+++ b/parm/forecast/globnest/input.nml.tmp
@@ -153,7 +153,7 @@
        lradar         = .true.
        avg_max_length = 3600.
        h2o_phys       = .true.
-       fhcyc          = 24.
+       fhcyc          = 0.
        use_ufo        = .true.
        pre_rad        = .false.
        imp_physics    = 11

--- a/parm/forecast/globnest/input_nest02.nml.tmp
+++ b/parm/forecast/globnest/input_nest02.nml.tmp
@@ -142,7 +142,7 @@
        lradar         = .true.
        avg_max_length = 3600.
        h2o_phys       = .true.
-       fhcyc          = 24.
+       fhcyc          = 0.
        use_ufo        = .true.
        pre_rad        = .false.
        imp_physics    = 11

--- a/parm/forecast/regional/input.nml.tmp
+++ b/parm/forecast/regional/input.nml.tmp
@@ -146,7 +146,7 @@
        lradar         = .true.
        avg_max_length = 3600.
        h2o_phys       = .true.
-       fhcyc          = 24.
+       fhcyc          = 0.
        use_ufo        = .true.
        pre_rad        = .false.
        imp_physics    = 11


### PR DESCRIPTION
for both regional and globalnest configurations.
fhcyc is the time period to reset some surface characteristic variables

## Description of changes  
Provide a description of what this PR does. What bug does it fix, or what feature does it add? Do you expect that this PR will change answers, and if so, under what circumstances? If this PR is for a physics innovation, please provide references to any relevant scientific papers.

## Issues addressed (optional)
If this PR addresses one or more issues, please provide link(s) to the issue(s) here.

## Dependencies
If submodule PRs are required, please link them below. For example:
- hafs-community/ufs-weather-model/pull/<pr_number>
- hafs-community/GSI/pull/<pr_number>
- hafs-community/ccpp-physics/pull/<pr_number>

## Contributors (optional)
If others worked on this PR besides the author, please include their user names here (using @Mention).

## Tests conducted
What testing has been conducted on the PR thus far? Describe the nature of any scientific or technical tests, including relevant details about the configuration(s) (e.g., cold versus warm start, number of cycles, forecast length, whether data assimilation was performed, etc). What platform(s) were used for testing?

## Application-level regression test status  
Running the HAFS application-level regression tests is currently performed by code reviewers after the developer creates the initial PR. As regression tests are conducted, the testers should use the checklist below to indicate **successful** regression tests. You may add other tests as needed. If a test fails, do not check the box. Instead, describe the failure in the PR comments, noting the platform where the test failed.

- [ ] Jet
- [ ] Hera
- [ ] Orion
- [ ] WCOSS Dell P3
- [ ] WCOSS Cray
